### PR TITLE
Support non-full day event timestamps

### DIFF
--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -151,7 +151,7 @@ module.exports = {
           message += ' would '
         }
         message += `be able to attend "${evt.getName()}" on `
-        message += elided(accepted.map(p => `*${p.date().format('D MMMM YYYY')}*`))
+        message += elided(accepted.map(p => `*${p.startDate().format('D MMMM YYYY')}*`))
 
         if (rejected.length > 0) {
           message += ', but '
@@ -169,7 +169,7 @@ module.exports = {
           message += `"${evt.getName()}" `
         }
         message += 'on '
-        message += elided(rejected.map(p => `*${p.date().format('D MMMM YYYY')}*`))
+        message += elided(rejected.map(p => `*${p.startDate().format('D MMMM YYYY')}*`))
       }
 
       message += '.'

--- a/lib/commands/helpers.js
+++ b/lib/commands/helpers.js
@@ -1,4 +1,4 @@
-const moment = require('moment-timezone')
+const {Timespan} = require('../timespan')
 
 function plural (count, singular, plural = singular + 's') {
   if (count === 1) {
@@ -30,7 +30,7 @@ class EventManipulator {
     if (!at) return false
     this.hadAt = true
 
-    const ts = moment.tz(at, moment.ISO_8601, true, this.context.userTz)
+    const ts = Timespan.parse(at, this.context.userTz)
     if (ts.isValid()) {
       this.evt.proposeDate(ts)
       this.evt.acceptProposal(uid, 0)
@@ -58,7 +58,7 @@ class EventManipulator {
     }
 
     for (const proposeTs of propose) {
-      const ts = moment.tz(proposeTs, moment.ISO_8601, true, this.context.userTz)
+      const ts = Timespan.parse(proposeTs, this.context.userTz)
       if (ts.isValid()) {
         const ind = this.evt.proposeDate(ts)
         this.evt.acceptProposal(uid, ind)

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   register (robot, msg, yargs) {
-    const userTz = msg.message.user.tz || 'America/New_York'
+    const userTz = robot['hubot-events'].getUserTz(msg)
     const now = robot['hubot-events'].now(userTz)
 
     function wrapHandler (h) {

--- a/lib/event.js
+++ b/lib/event.js
@@ -261,11 +261,11 @@ class Event {
   asLine () {
     let str = `\`${this.id}\` `
     if (this.isFinalized()) {
-      str += `${this.name} ${this.finalProposal().startDate().format('D MMMM YYYY')}`
+      str += `${this.name} ${this.finalProposal().getTimespan().renderStart()}`
     } else {
       str += `_${this.name}_`
       if (this.proposals.length > 0) str += ' '
-      str += this.proposals.map(p => p.startDate().format('D MMMM YYYY')).join(', ')
+      str += this.proposals.map(p => p.getTimespan().renderStart()).join(', ')
     }
     return str
   }
@@ -286,7 +286,7 @@ class Event {
         })
       } else {
         const value = this.proposals.map((proposal, index) => {
-          let str = `[${index}] ${proposal.startDate().format('D MMMM YYYY')}`
+          let str = `[${index}] ${proposal.getTimespan().renderRange()}`
           str += ` _${proposal.startDate().from(ref)}_`
           if (proposal.isLeading()) {
             str += ' :medal:'
@@ -317,7 +317,7 @@ class Event {
       const proposal = this.finalProposal()
       a.fields.push({
         title: 'When',
-        value: `${proposal.startDate().format('D MMMM YYYY')} _${proposal.startDate().from(ref)}_`
+        value: `${proposal.getTimespan().renderRange()} _${proposal.startDate().from(ref)}_`
       })
 
       if (this.invitees.size > 0) {

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,18 +1,18 @@
-const moment = require('moment-timezone')
-
 const {buildInvalidProposalError, buildUnfinalizedEventError, buildFinalizedEventError} = require('./errors')
+const {Timespan} = require('./timespan')
 
 class Proposal {
-  constructor (ts) {
-    this.start = ts
-    this.end = this.start.clone().add(1, 'hour')
+  constructor (timespan) {
+    this.timespan = timespan
     this.accepted = new Set()
     this.leading = false
   }
 
-  startDate () { return this.start }
+  getTimespan () { return this.timespan }
 
-  endDate () { return this.end }
+  startDate () { return this.timespan.getStart() }
+
+  endDate () { return this.timespan.getEnd() }
 
   yesCount () { return this.accepted.size }
 
@@ -32,16 +32,13 @@ class Proposal {
 
   serialize () {
     return {
-      start: this.start.valueOf(),
-      startZone: this.start.tz(),
-      end: this.end.valueOf(),
-      endZone: this.end.tz(),
+      timespan: this.timespan.serialize(),
       accepted: Array.from(this.accepted)
     }
   }
 
   static deserialize (payload) {
-    const p = new Proposal(moment.tz(payload.start, payload.startZone))
+    const p = new Proposal(Timespan.deserialize(payload.timespan))
     p.accepted = new Set(payload.accepted)
     return p
   }

--- a/lib/event.js
+++ b/lib/event.js
@@ -4,12 +4,15 @@ const {buildInvalidProposalError, buildUnfinalizedEventError, buildFinalizedEven
 
 class Proposal {
   constructor (ts) {
-    this.ts = ts
+    this.start = ts
+    this.end = this.start.clone().add(1, 'hour')
     this.accepted = new Set()
     this.leading = false
   }
 
-  date () { return this.ts }
+  startDate () { return this.start }
+
+  endDate () { return this.end }
 
   yesCount () { return this.accepted.size }
 
@@ -29,14 +32,16 @@ class Proposal {
 
   serialize () {
     return {
-      ts: this.ts.valueOf(),
-      zone: this.ts.tz(),
+      start: this.start.valueOf(),
+      startZone: this.start.tz(),
+      end: this.end.valueOf(),
+      endZone: this.end.tz(),
       accepted: Array.from(this.accepted)
     }
   }
 
   static deserialize (payload) {
-    const p = new Proposal(moment.tz(payload.ts, payload.zone))
+    const p = new Proposal(moment.tz(payload.start, payload.startZone))
     p.accepted = new Set(payload.accepted)
     return p
   }
@@ -68,10 +73,10 @@ class Event {
     const p = new Proposal(ts)
     this.proposals.push(p)
 
-    if (!this.earliest || p.date().isBefore(this.earliest.date())) {
+    if (!this.earliest || p.startDate().isBefore(this.earliest.startDate())) {
       this.earliest = p
     }
-    if (!this.latest || p.date().isAfter(this.latest.date())) {
+    if (!this.latest || p.startDate().isAfter(this.latest.startDate())) {
       this.latest = p
     }
 
@@ -83,7 +88,7 @@ class Event {
       this.earliest = this.proposals.reduce((min, p, ind) => {
         if (ind === index) return min
         if (min === null) return p
-        if (p.date().isBefore(min.date())) return p
+        if (p.startDate().isBefore(min.startDate())) return p
         return min
       }, null)
     }
@@ -92,7 +97,7 @@ class Event {
       this.latest = this.proposals.reduce((max, p, ind) => {
         if (ind === index) return max
         if (max === null) return p
-        if (p.date().isAfter(max.date())) return p
+        if (p.startDate().isAfter(max.startDate())) return p
         return max
       }, null)
     }
@@ -198,9 +203,9 @@ class Event {
 
   earliestComparisonDate () {
     if (this.isFinalized()) {
-      return this.finalProposal().date()
+      return this.finalProposal().startDate()
     } else if (this.earliest) {
-      return this.earliest.date()
+      return this.earliest.startDate()
     } else {
       return null
     }
@@ -208,9 +213,9 @@ class Event {
 
   latestComparisonDate () {
     if (this.isFinalized()) {
-      return this.finalProposal().date()
+      return this.finalProposal().startDate()
     } else if (this.latest) {
-      return this.latest.date()
+      return this.latest.startDate()
     } else {
       return null
     }
@@ -259,11 +264,11 @@ class Event {
   asLine () {
     let str = `\`${this.id}\` `
     if (this.isFinalized()) {
-      str += `${this.name} ${this.finalProposal().date().format('D MMMM YYYY')}`
+      str += `${this.name} ${this.finalProposal().startDate().format('D MMMM YYYY')}`
     } else {
       str += `_${this.name}_`
       if (this.proposals.length > 0) str += ' '
-      str += this.proposals.map(p => p.date().format('D MMMM YYYY')).join(', ')
+      str += this.proposals.map(p => p.startDate().format('D MMMM YYYY')).join(', ')
     }
     return str
   }
@@ -284,8 +289,8 @@ class Event {
         })
       } else {
         const value = this.proposals.map((proposal, index) => {
-          let str = `[${index}] ${proposal.date().format('D MMMM YYYY')}`
-          str += ` _${proposal.date().from(ref)}_`
+          let str = `[${index}] ${proposal.startDate().format('D MMMM YYYY')}`
+          str += ` _${proposal.startDate().from(ref)}_`
           if (proposal.isLeading()) {
             str += ' :medal:'
           }
@@ -315,7 +320,7 @@ class Event {
       const proposal = this.finalProposal()
       a.fields.push({
         title: 'When',
-        value: `${proposal.date().format('D MMMM YYYY')} _${proposal.date().from(ref)}_`
+        value: `${proposal.startDate().format('D MMMM YYYY')} _${proposal.startDate().from(ref)}_`
       })
 
       if (this.invitees.size > 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,10 @@ module.exports = function (robot) {
       }
     },
 
+    getUserTz (msg) {
+      return msg.message.user.tz || 'America/New_York'
+    },
+
     now (userTz) {
       return moment.tz(userTz)
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,10 +45,24 @@ module.exports = function (robot) {
   }
 
   robot.respond(/event ([^]*)/i, function (msg) {
+    const userTz = robot['hubot-events'].getUserTz(msg)
+
     const y = commands.register(robot, msg, yargs.usage('event [create|edit|delete|list] <args>'))
       .strict(true)
       .version(false)
       .wrap(null)
+      .epilogue(
+        'Timestamps for `--propose` and `--at` must be specified in ' +
+        '<ISO 8601 format|https://en.wikipedia.org/wiki/ISO_8601>. ' +
+        `For example, right now is \`${moment.tz(userTz).toISOString()}\`. The day, month, and year default to today ` +
+        'if omitted. Hours, minutes, and seconds default to 0 if omitted, and if all three are absent a *full-day* ' +
+        'event is created.\n\n' +
+        'Events that are not full-day default to 1 hour in duration. To specify a longer or shorter event, specify ' +
+        'the endpoints explicitly with ' +
+        `\`${moment.tz(userTz).toISOString()}..${moment.tz(userTz).add(2, 'hours').toISOString()}\`` +
+        ', or specify a starting point and a duration or ' +
+        `\`${moment.tz(userTz).toISOString()}+2h\`.`
+      )
 
     y.parse(msg.match[1], (err, argv, output) => {
       if (err) {

--- a/lib/timespan.js
+++ b/lib/timespan.js
@@ -1,0 +1,115 @@
+const moment = require('moment-timezone')
+
+function fullDay (m) {
+  return !/H|h|k|m|s|S/.test(m.creationData().format)
+}
+
+function parseDuration (str) {
+  if (!/^(\d+[wdmhs]\s*)+$/i.test(str)) return moment.duration(NaN)
+
+  const units = {}
+
+  const rx = /(\d+)([wdmhs])/gi
+  let match
+  while ((match = rx.exec(str)) !== null) {
+    units[match[2]] = parseInt(match[1])
+  }
+
+  return moment.duration(units)
+}
+
+class Timespan {
+  constructor (start, end, full) {
+    this.start = start
+    this.end = end
+    this.full = full
+  }
+
+  isFullDay () {
+    return this.full
+  }
+
+  isValid () {
+    return this.start.isValid() && this.end.isValid()
+  }
+
+  getStart () {
+    return this.start
+  }
+
+  getEnd () {
+    return this.end
+  }
+
+  serialize () {
+    return {
+      start: this.start.valueOf(),
+      end: this.end.valueOf(),
+      tz: this.start.tz(),
+      full: this.full
+    }
+  }
+
+  renderStart () {
+    if (this.isFullDay()) {
+      return `<!date^${this.start.unix()}^{date}^${this.start.format('D MMMM YYYY')}>`
+    } else {
+      return `<!date^${this.start.unix()}^{date_short} {time}^${this.start.format('D MMM YYYY h:mma')}>`
+    }
+  }
+
+  renderRange () {
+    let str = this.renderStart()
+
+    if (this.isFullDay()) {
+      if (!this.end.isSame(this.start, 'day')) {
+        str += ` to <!date^${this.end.unix()}^{date}^${this.end.format('D MMMM YYYY')}>`
+      }
+    } else {
+      if (!this.end.isSame(this.start, 'day')) {
+        str += ` to <!date^${this.end.unix()}^{date_short} {time}^${this.end.format('D MMM YYYY h:mma')}>`
+      } else {
+        str += ` to <!date^${this.end.unix()}^{time}^${this.end.format('hh:mma')}>`
+      }
+    }
+
+    return str
+  }
+
+  static parse (str, tz) {
+    const sep = /\.+|\+/.exec(str)
+    if (!sep) {
+      const start = moment.tz(str, moment.ISO_8601, true, tz)
+      const full = fullDay(start)
+      const end = full ? start.clone().endOf('day') : start.clone().add(1, 'hours')
+      return new Timespan(start, end, full)
+    } else {
+      const firstPart = str.substring(0, sep.index)
+      const secondPart = str.substring(sep.index + sep[0].length)
+
+      const start = moment.tz(firstPart, moment.ISO_8601, true, tz)
+      if (sep[0] === '+') {
+        const duration = parseDuration(secondPart)
+        const end = duration.isValid() ? start.clone().add(duration) : moment.invalid()
+        const full = fullDay(start) && Number.isInteger(duration.asDays())
+        if (full) end.endOf('day')
+        return new Timespan(start, end, full)
+      } else {
+        const end = moment.tz(secondPart, moment.ISO_8601, true, tz)
+        const full = fullDay(start) && fullDay(end)
+        if (full) end.endOf('day')
+        return new Timespan(start, end, full)
+      }
+    }
+  }
+
+  static deserialize (payload) {
+    return new Timespan(
+      moment.tz(payload.start, payload.tz),
+      moment.tz(payload.end, payload.tz),
+      payload.full
+    )
+  }
+}
+
+module.exports = {Timespan}

--- a/lib/timespan.js
+++ b/lib/timespan.js
@@ -82,7 +82,6 @@ class Timespan {
       const start = moment.tz(str, moment.ISO_8601, true, tz)
       const full = fullDay(start)
       const end = full ? start.clone().endOf('day') : start.clone().add(1, 'hours')
-      console.log({ branch: 'single', start, end, full })
       return new Timespan(start, end, full)
     } else {
       const firstPart = str.substring(0, sep.index)
@@ -94,13 +93,11 @@ class Timespan {
         const end = duration.isValid() ? start.clone().add(duration) : moment.invalid()
         const full = fullDay(start) && Number.isInteger(duration.asDays())
         if (full) end.endOf('day')
-        console.log({ branch: 'date+duration', start, end, full })
         return new Timespan(start, end, full)
       } else {
         const end = moment.tz(secondPart, moment.ISO_8601, true, tz)
         const full = fullDay(start) && fullDay(end)
         if (full) end.endOf('day')
-        console.log({ branch: 'date..date', start, end, full })
         return new Timespan(start, end, full)
       }
     }

--- a/lib/timespan.js
+++ b/lib/timespan.js
@@ -82,6 +82,7 @@ class Timespan {
       const start = moment.tz(str, moment.ISO_8601, true, tz)
       const full = fullDay(start)
       const end = full ? start.clone().endOf('day') : start.clone().add(1, 'hours')
+      console.log({ branch: 'single', start, end, full })
       return new Timespan(start, end, full)
     } else {
       const firstPart = str.substring(0, sep.index)
@@ -93,11 +94,13 @@ class Timespan {
         const end = duration.isValid() ? start.clone().add(duration) : moment.invalid()
         const full = fullDay(start) && Number.isInteger(duration.asDays())
         if (full) end.endOf('day')
+        console.log({ branch: 'date+duration', start, end, full })
         return new Timespan(start, end, full)
       } else {
         const end = moment.tz(secondPart, moment.ISO_8601, true, tz)
         const full = fullDay(start) && fullDay(end)
         if (full) end.endOf('day')
+        console.log({ branch: 'date..date', start, end, full })
         return new Timespan(start, end, full)
       }
     }

--- a/test/bot-context.js
+++ b/test/bot-context.js
@@ -1,23 +1,23 @@
 const Helper = require('hubot-test-helper')
-const moment = require('moment-timezone')
+const {Timespan} = require('../lib/timespan')
 
 const helper = new Helper('../lib/index.js')
 
-const lastWeek = moment.tz('2017-11-10', moment.ISO_8601, 'America/New_York')
-const yesterday = moment.tz('2017-11-17', moment.ISO_8601, 'America/New_York')
-const now = moment.tz('2017-11-18', moment.ISO_8601, 'America/New_York')
-const tomorrow = moment.tz('2017-11-19', moment.ISO_8601, 'America/New_York')
-const nextWeek = moment.tz('2017-11-25', moment.ISO_8601, 'America/New_York')
-const nextMonth = moment.tz('2017-12-16', moment.ISO_8601, 'America/New_York')
-const nextYear = moment.tz('2018-01-10', moment.ISO_8601, 'America/New_York')
 const TZ = 'America/Los_Angeles'
 
+const lastWeek = Timespan.parse('2017-11-10', TZ)
+const yesterday = Timespan.parse('2017-11-17', TZ)
+const now = Timespan.parse('2017-11-18', TZ)
+const tomorrow = Timespan.parse('2017-11-19', TZ)
+const nextWeek = Timespan.parse('2017-11-25', TZ)
+const nextMonth = Timespan.parse('2017-12-16', TZ)
+const nextYear = Timespan.parse('2018-01-10', TZ)
 
 class BotContext {
   constructor () {
     this.room = helper.createRoom({httpd: false})
-    this.room.robot['hubot-events'].now = userTz => now.clone().tz(userTz)
     this.room.robot['hubot-events'].getUserTz = () => TZ
+    this.room.robot['hubot-events'].now = userTz => now.getStart().clone().tz(userTz)
   }
 
   createUser (uid, username) {

--- a/test/bot-context.js
+++ b/test/bot-context.js
@@ -10,11 +10,14 @@ const tomorrow = moment.tz('2017-11-19', moment.ISO_8601, 'America/New_York')
 const nextWeek = moment.tz('2017-11-25', moment.ISO_8601, 'America/New_York')
 const nextMonth = moment.tz('2017-12-16', moment.ISO_8601, 'America/New_York')
 const nextYear = moment.tz('2018-01-10', moment.ISO_8601, 'America/New_York')
+const TZ = 'America/Los_Angeles'
+
 
 class BotContext {
   constructor () {
     this.room = helper.createRoom({httpd: false})
     this.room.robot['hubot-events'].now = userTz => now.clone().tz(userTz)
+    this.room.robot['hubot-events'].getUserTz = () => TZ
   }
 
   createUser (uid, username) {

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -84,7 +84,7 @@ describe('event create', function () {
           title: 'Unable to parse proposed dates',
           text:
             'Please use <ISO 8601|https://en.wikipedia.org/wiki/ISO_8601> to format date arguments. ' +
-            'For example, right now is `2017-11-18T05:00:00.000Z`. The time bit may be omitted for whole-day events.' +
+            'For example, right now is `2017-11-18T08:00:00.000Z`. The time bit may be omitted for whole-day events.' +
             '\n\nI couldn\'t parse: `2017-12-36`, `february`.',
           color: 'danger',
           mrkdwn_in: ['text']

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -43,7 +43,9 @@ describe('event create', function () {
         fields: [
           {
             title: 'Proposed Dates',
-            value: '[0] 10 December 2017 _in 22 days_ x1\n[1] 11 December 2017 _in 23 days_ x1'
+            value:
+              '[0] <!date^1512892800^{date}^10 December 2017> _in 22 days_ x1\n' +
+              '[1] <!date^1512979200^{date}^11 December 2017> _in 23 days_ x1'
           },
           {
             title: 'Who',
@@ -70,7 +72,7 @@ describe('event create', function () {
           fields: [
             {
               title: 'Proposed Dates',
-              value: '[0] 12 December 2017 _in 24 days_ x1'
+              value: '[0] <!date^1513065600^{date}^12 December 2017> _in 24 days_ x1'
             },
             {
               title: 'Who',
@@ -129,7 +131,7 @@ describe('event create', function () {
         fallback: 'XYZ: Bar',
         title: '`XYZ` :calendar: Bar',
         fields: [
-          {title: 'When', value: '19 November 2017 _in a day_'},
+          {title: 'When', value: '<!date^1511078400^{date}^19 November 2017> _in a day_'},
           {title: 'Who', value: '_Attendees_\n:white_check_mark: <@U1> | :grey_question: <@U2>'}
         ],
         mrkdwn_in: ['fields']

--- a/test/edit.test.js
+++ b/test/edit.test.js
@@ -35,8 +35,8 @@ describe('event edit', function () {
           {
             title: 'Proposed Dates',
             value:
-              '[0] 19 November 2017 _in a day_\n' +
-              '[1] 25 November 2017 _in 7 days_'
+              '[0] <!date^1511078400^{date}^19 November 2017> _in a day_\n' +
+              '[1] <!date^1511596800^{date}^25 November 2017> _in 7 days_'
           },
           {
             title: 'Who',
@@ -58,9 +58,9 @@ describe('event edit', function () {
           {
             title: 'Proposed Dates',
             value:
-              '[0] 19 November 2017 _in a day_\n' +
-              '[1] 25 November 2017 _in 7 days_\n' +
-              '[2] 20 November 2017 _in 2 days_ x1'
+              '[0] <!date^1511078400^{date}^19 November 2017> _in a day_\n' +
+              '[1] <!date^1511596800^{date}^25 November 2017> _in 7 days_\n' +
+              '[2] <!date^1511164800^{date}^20 November 2017> _in 2 days_ x1'
           },
           {
             title: 'Who',
@@ -81,7 +81,7 @@ describe('event edit', function () {
         fields: [
           {
             title: 'Proposed Dates',
-            value: '[1] 25 November 2017 _in 7 days_'
+            value: '[1] <!date^1511596800^{date}^25 November 2017> _in 7 days_'
           },
           {
             title: 'Who',
@@ -102,7 +102,9 @@ describe('event edit', function () {
         fields: [
           {
             title: 'Proposed Dates',
-            value: '[0] 19 November 2017 _in a day_\n[1] 25 November 2017 _in 7 days_'
+            value:
+              '[0] <!date^1511078400^{date}^19 November 2017> _in a day_\n' +
+              '[1] <!date^1511596800^{date}^25 November 2017> _in 7 days_'
           },
           {
             title: 'Who',
@@ -124,8 +126,8 @@ describe('event edit', function () {
           {
             title: 'Proposed Dates',
             value:
-              '[0] 19 November 2017 _in a day_\n' +
-              '[1] 25 November 2017 _in 7 days_'
+              '[0] <!date^1511078400^{date}^19 November 2017> _in a day_\n' +
+              '[1] <!date^1511596800^{date}^25 November 2017> _in 7 days_'
           },
           {
             title: 'Who',
@@ -147,8 +149,8 @@ describe('event edit', function () {
           {
             title: 'Proposed Dates',
             value:
-              '[0] 19 November 2017 _in a day_\n' +
-              '[1] 25 November 2017 _in 7 days_'
+              '[0] <!date^1511078400^{date}^19 November 2017> _in a day_\n' +
+              '[1] <!date^1511596800^{date}^25 November 2017> _in 7 days_'
           },
           {
             title: 'Who',
@@ -215,7 +217,7 @@ describe('event edit', function () {
         fields: [
           {
             title: 'When',
-            value: '19 November 2017 _in a day_'
+            value: '<!date^1511078400^{date}^19 November 2017> _in a day_'
           },
           {
             title: 'Who',
@@ -283,8 +285,8 @@ describe('event edit', function () {
             {
               title: 'Proposed Dates',
               value:
-                '[0] 19 November 2017 _in a day_\n' +
-                '[1] 25 November 2017 _in 7 days_'
+                '[0] <!date^1511078400^{date}^19 November 2017> _in a day_\n' +
+                '[1] <!date^1511596800^{date}^25 November 2017> _in 7 days_'
             },
             {
               title: 'Who',

--- a/test/event-store.test.js
+++ b/test/event-store.test.js
@@ -91,8 +91,8 @@ describe('EventStore', function () {
     no2.invite('u0')
 
     const results = store.search({
-      after: ts.nextWeek,
-      before: ts.nextMonth,
+      after: ts.nextWeek.getStart(),
+      before: ts.nextMonth.getStart(),
       invited: 'u0'
     })
     assert.equal(results.size(), 2)

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -185,7 +185,9 @@ describe('Event', function () {
       const a = evt.asAttachment(ts.now.getStart())
       assert.deepEqual(a.fields, [{
         title: 'Proposed Dates',
-        value: '[0] 19 November 2017 _in a day_\n[1] 25 November 2017 _in 7 days_'
+        value:
+          '[0] <!date^1511078400^{date}^19 November 2017> _in a day_\n' +
+          '[1] <!date^1511596800^{date}^25 November 2017> _in 7 days_'
       }])
     })
 
@@ -215,8 +217,8 @@ describe('Event', function () {
         {
           title: 'Proposed Dates',
           value:
-            '[0] 19 November 2017 _in a day_ :medal: x2\n' +
-            '[1] 25 November 2017 _in 7 days_ x1'
+            '[0] <!date^1511078400^{date}^19 November 2017> _in a day_ :medal: x2\n' +
+            '[1] <!date^1511596800^{date}^25 November 2017> _in 7 days_ x1'
         },
         {
           title: 'Who',

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -18,8 +18,8 @@ describe('Event', function () {
       evt.proposeDate(ts.nextWeek)
 
       assert.deepEqual(evt.proposalKeys(), [0, 1])
-      assert.equal(evt.proposal(0).date(), ts.tomorrow)
-      assert.equal(evt.proposal(1).date(), ts.nextWeek)
+      assert.equal(evt.proposal(0).startDate(), ts.tomorrow)
+      assert.equal(evt.proposal(1).startDate(), ts.nextWeek)
     })
 
     it('removes proposed dates', function () {
@@ -28,7 +28,7 @@ describe('Event', function () {
       evt.unpropose(0)
 
       assert.deepEqual(evt.proposalKeys(), [1])
-      assert.equal(evt.proposal(1).date(), ts.nextMonth)
+      assert.equal(evt.proposal(1).startDate(), ts.nextMonth)
       assert.throws(() => evt.proposal(0), 'Invalid proposed date')
     })
 
@@ -57,13 +57,13 @@ describe('Event', function () {
       evt.proposeDate(ts.nextWeek)
       evt.proposeDate(ts.nextMonth)
 
-      assert.equal(evt.proposal(0).date(), ts.tomorrow)
+      assert.equal(evt.proposal(0).startDate(), ts.tomorrow)
       assert.equal(evt.proposal(0).yesCount(), 0)
       assert.isFalse(evt.proposal(0).isLeading())
-      assert.equal(evt.proposal(1).date(), ts.nextWeek)
+      assert.equal(evt.proposal(1).startDate(), ts.nextWeek)
       assert.equal(evt.proposal(1).yesCount(), 0)
       assert.isFalse(evt.proposal(1).isLeading())
-      assert.equal(evt.proposal(2).date(), ts.nextMonth)
+      assert.equal(evt.proposal(2).startDate(), ts.nextMonth)
       assert.equal(evt.proposal(2).yesCount(), 0)
       assert.isFalse(evt.proposal(2).isLeading())
 
@@ -74,13 +74,13 @@ describe('Event', function () {
       evt.acceptProposal('reostra', 1)
       evt.acceptProposal('reostra', 2)
 
-      assert.equal(evt.proposal(0).date(), ts.tomorrow)
+      assert.equal(evt.proposal(0).startDate(), ts.tomorrow)
       assert.equal(evt.proposal(0).yesCount(), 3)
       assert.isTrue(evt.proposal(0).isLeading())
-      assert.equal(evt.proposal(1).date(), ts.nextWeek)
+      assert.equal(evt.proposal(1).startDate(), ts.nextWeek)
       assert.equal(evt.proposal(1).yesCount(), 2)
       assert.isFalse(evt.proposal(1).isLeading())
-      assert.equal(evt.proposal(2).date(), ts.nextMonth)
+      assert.equal(evt.proposal(2).startDate(), ts.nextMonth)
       assert.equal(evt.proposal(2).yesCount(), 1)
       assert.isFalse(evt.proposal(2).isLeading())
     })
@@ -248,8 +248,8 @@ describe('Event', function () {
 
     assert.equal(evt1.getName(), "Party at Frey's House")
     assert.deepEqual(evt1.proposalKeys(), [0, 1])
-    assert.equal(evt1.proposal(0).date().valueOf(), ts.tomorrow.valueOf())
-    assert.equal(evt1.proposal(1).date().valueOf(), ts.nextWeek.valueOf())
+    assert.equal(evt1.proposal(0).startDate().valueOf(), ts.tomorrow.valueOf())
+    assert.equal(evt1.proposal(1).startDate().valueOf(), ts.nextWeek.valueOf())
     assert.deepEqual(evt1.getInvitees(), ['<@U123>', '<@U456>', '<@U789>', '<@U111>'])
   })
 

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -18,8 +18,8 @@ describe('Event', function () {
       evt.proposeDate(ts.nextWeek)
 
       assert.deepEqual(evt.proposalKeys(), [0, 1])
-      assert.equal(evt.proposal(0).startDate(), ts.tomorrow)
-      assert.equal(evt.proposal(1).startDate(), ts.nextWeek)
+      assert.equal(evt.proposal(0).startDate(), ts.tomorrow.getStart())
+      assert.equal(evt.proposal(1).startDate(), ts.nextWeek.getStart())
     })
 
     it('removes proposed dates', function () {
@@ -28,7 +28,7 @@ describe('Event', function () {
       evt.unpropose(0)
 
       assert.deepEqual(evt.proposalKeys(), [1])
-      assert.equal(evt.proposal(1).startDate(), ts.nextMonth)
+      assert.equal(evt.proposal(1).startDate(), ts.nextMonth.getStart())
       assert.throws(() => evt.proposal(0), 'Invalid proposed date')
     })
 
@@ -57,13 +57,13 @@ describe('Event', function () {
       evt.proposeDate(ts.nextWeek)
       evt.proposeDate(ts.nextMonth)
 
-      assert.equal(evt.proposal(0).startDate(), ts.tomorrow)
+      assert.equal(evt.proposal(0).getTimespan(), ts.tomorrow)
       assert.equal(evt.proposal(0).yesCount(), 0)
       assert.isFalse(evt.proposal(0).isLeading())
-      assert.equal(evt.proposal(1).startDate(), ts.nextWeek)
+      assert.equal(evt.proposal(1).getTimespan(), ts.nextWeek)
       assert.equal(evt.proposal(1).yesCount(), 0)
       assert.isFalse(evt.proposal(1).isLeading())
-      assert.equal(evt.proposal(2).startDate(), ts.nextMonth)
+      assert.equal(evt.proposal(2).getTimespan(), ts.nextMonth)
       assert.equal(evt.proposal(2).yesCount(), 0)
       assert.isFalse(evt.proposal(2).isLeading())
 
@@ -74,13 +74,13 @@ describe('Event', function () {
       evt.acceptProposal('reostra', 1)
       evt.acceptProposal('reostra', 2)
 
-      assert.equal(evt.proposal(0).startDate(), ts.tomorrow)
+      assert.equal(evt.proposal(0).getTimespan(), ts.tomorrow)
       assert.equal(evt.proposal(0).yesCount(), 3)
       assert.isTrue(evt.proposal(0).isLeading())
-      assert.equal(evt.proposal(1).startDate(), ts.nextWeek)
+      assert.equal(evt.proposal(1).getTimespan(), ts.nextWeek)
       assert.equal(evt.proposal(1).yesCount(), 2)
       assert.isFalse(evt.proposal(1).isLeading())
-      assert.equal(evt.proposal(2).startDate(), ts.nextMonth)
+      assert.equal(evt.proposal(2).getTimespan(), ts.nextMonth)
       assert.equal(evt.proposal(2).yesCount(), 1)
       assert.isFalse(evt.proposal(2).isLeading())
     })
@@ -182,7 +182,7 @@ describe('Event', function () {
       evt.proposeDate(ts.tomorrow)
       evt.proposeDate(ts.nextWeek)
 
-      const a = evt.asAttachment(ts.now)
+      const a = evt.asAttachment(ts.now.getStart())
       assert.deepEqual(a.fields, [{
         title: 'Proposed Dates',
         value: '[0] 19 November 2017 _in a day_\n[1] 25 November 2017 _in 7 days_'
@@ -210,7 +210,7 @@ describe('Event', function () {
       // U111 can make it, but wasn't on the initial invite list
       evt.acceptProposal('<@U111>', 1)
 
-      const a = evt.asAttachment(ts.now)
+      const a = evt.asAttachment(ts.now.getStart())
       assert.deepEqual(a.fields, [
         {
           title: 'Proposed Dates',
@@ -248,8 +248,8 @@ describe('Event', function () {
 
     assert.equal(evt1.getName(), "Party at Frey's House")
     assert.deepEqual(evt1.proposalKeys(), [0, 1])
-    assert.equal(evt1.proposal(0).startDate().valueOf(), ts.tomorrow.valueOf())
-    assert.equal(evt1.proposal(1).startDate().valueOf(), ts.nextWeek.valueOf())
+    assert.equal(evt1.proposal(0).startDate().valueOf(), ts.tomorrow.getStart().valueOf())
+    assert.equal(evt1.proposal(1).startDate().valueOf(), ts.nextWeek.getStart().valueOf())
     assert.deepEqual(evt1.getInvitees(), ['<@U123>', '<@U456>', '<@U789>', '<@U111>'])
   })
 
@@ -324,9 +324,9 @@ describe('Event', function () {
       evt.proposeDate(ts.tomorrow)
       evt.finalize(0)
 
-      assert.isFalse(evt.matches({before: ts.now}))
-      assert.isTrue(evt.matches({before: ts.tomorrow}))
-      assert.isTrue(evt.matches({before: ts.nextWeek}))
+      assert.isFalse(evt.matches({before: ts.now.getStart()}))
+      assert.isTrue(evt.matches({before: ts.tomorrow.getStart()}))
+      assert.isTrue(evt.matches({before: ts.nextWeek.getStart()}))
     })
 
     it('matches an unfinalized event before a timestamp', function () {
@@ -334,9 +334,9 @@ describe('Event', function () {
       evt.proposeDate(ts.nextMonth)
       evt.proposeDate(ts.tomorrow)
 
-      assert.isFalse(evt.matches({before: ts.now}))
-      assert.isTrue(evt.matches({before: ts.tomorrow}))
-      assert.isTrue(evt.matches({before: ts.nextWeek}))
+      assert.isFalse(evt.matches({before: ts.now.getStart()}))
+      assert.isTrue(evt.matches({before: ts.tomorrow.getStart()}))
+      assert.isTrue(evt.matches({before: ts.nextWeek.getStart()}))
     })
 
     it('matches a finalized event after a timestamp', function () {
@@ -344,9 +344,9 @@ describe('Event', function () {
       evt.proposeDate(ts.tomorrow)
       evt.finalize(0)
 
-      assert.isTrue(evt.matches({after: ts.now}))
-      assert.isTrue(evt.matches({after: ts.tomorrow}))
-      assert.isFalse(evt.matches({after: ts.nextWeek}))
+      assert.isTrue(evt.matches({after: ts.now.getStart()}))
+      assert.isTrue(evt.matches({after: ts.tomorrow.getStart()}))
+      assert.isFalse(evt.matches({after: ts.nextWeek.getStart()}))
     })
 
     it('matches an unfinalized event after a timestamp', function () {
@@ -354,9 +354,9 @@ describe('Event', function () {
       evt.proposeDate(ts.nextWeek)
       evt.proposeDate(ts.tomorrow)
 
-      assert.isTrue(evt.matches({after: ts.now}))
-      assert.isTrue(evt.matches({after: ts.nextWeek}))
-      assert.isFalse(evt.matches({after: ts.nextMonth}))
+      assert.isTrue(evt.matches({after: ts.now.getStart()}))
+      assert.isTrue(evt.matches({after: ts.nextWeek.getStart()}))
+      assert.isFalse(evt.matches({after: ts.nextMonth.getStart()}))
     })
 
     it('matches by finalized status', function () {

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -51,10 +51,10 @@ describe('event list', function () {
       bot.response(),
       '_Showing 5 of 7 events_\n' +
       '`6` _G_\n' +
-      '`2` C 18 November 2017\n' +
-      '`3` _D_ 19 November 2017\n' +
-      '`4` _E_ 25 November 2017, 16 December 2017\n' +
-      '`5` F 10 January 2018'
+      '`2` C <!date^1510992000^{date}^18 November 2017>\n' +
+      '`3` _D_ <!date^1511078400^{date}^19 November 2017>\n' +
+      '`4` _E_ <!date^1511596800^{date}^25 November 2017>, <!date^1513411200^{date}^16 December 2017>\n' +
+      '`5` F <!date^1515571200^{date}^10 January 2018>'
     )
   })
 
@@ -64,11 +64,11 @@ describe('event list', function () {
       bot.response(),
       '_Showing 6 of 7 events_\n' +
       '`6` _G_\n' +
-      '`0` A 10 November 2017\n' +
-      '`1` _B_ 17 November 2017\n' +
-      '`2` C 18 November 2017\n' +
-      '`3` _D_ 19 November 2017\n' +
-      '`4` _E_ 25 November 2017, 16 December 2017'
+      '`0` A <!date^1510300800^{date}^10 November 2017>\n' +
+      '`1` _B_ <!date^1510905600^{date}^17 November 2017>\n' +
+      '`2` C <!date^1510992000^{date}^18 November 2017>\n' +
+      '`3` _D_ <!date^1511078400^{date}^19 November 2017>\n' +
+      '`4` _E_ <!date^1511596800^{date}^25 November 2017>, <!date^1513411200^{date}^16 December 2017>'
     )
   })
 
@@ -78,9 +78,9 @@ describe('event list', function () {
       bot.response(),
       '_Showing 4 of 7 events_\n' +
       '`6` _G_\n' +
-      '`0` A 10 November 2017\n' +
-      '`1` _B_ 17 November 2017\n' +
-      '`2` C 18 November 2017'
+      '`0` A <!date^1510300800^{date}^10 November 2017>\n' +
+      '`1` _B_ <!date^1510905600^{date}^17 November 2017>\n' +
+      '`2` C <!date^1510992000^{date}^18 November 2017>'
     )
   })
 
@@ -90,9 +90,9 @@ describe('event list', function () {
       bot.response(),
       '_Showing 4 of 7 events_\n' +
       '`6` _G_\n' +
-      '`3` _D_ 19 November 2017\n' +
-      '`4` _E_ 25 November 2017, 16 December 2017\n' +
-      '`5` F 10 January 2018'
+      '`3` _D_ <!date^1511078400^{date}^19 November 2017>\n' +
+      '`4` _E_ <!date^1511596800^{date}^25 November 2017>, <!date^1513411200^{date}^16 December 2017>\n' +
+      '`5` F <!date^1515571200^{date}^10 January 2018>'
     )
   })
 
@@ -102,10 +102,10 @@ describe('event list', function () {
       bot.response(),
       '_Showing 5 of 7 events_\n' +
       '`6` _G_\n' +
-      '`2` C 18 November 2017\n' +
-      '`3` _D_ 19 November 2017\n' +
-      '`4` _E_ 25 November 2017, 16 December 2017\n' +
-      '`5` F 10 January 2018'
+      '`2` C <!date^1510992000^{date}^18 November 2017>\n' +
+      '`3` _D_ <!date^1511078400^{date}^19 November 2017>\n' +
+      '`4` _E_ <!date^1511596800^{date}^25 November 2017>, <!date^1513411200^{date}^16 December 2017>\n' +
+      '`5` F <!date^1515571200^{date}^10 January 2018>'
     )
   })
 
@@ -114,9 +114,9 @@ describe('event list', function () {
     assert.equal(
       bot.response(),
       '_Showing 3 of 7 events_\n' +
-      '`0` A 10 November 2017\n' +
-      '`2` C 18 November 2017\n' +
-      '`5` F 10 January 2018'
+      '`0` A <!date^1510300800^{date}^10 November 2017>\n' +
+      '`2` C <!date^1510992000^{date}^18 November 2017>\n' +
+      '`5` F <!date^1515571200^{date}^10 January 2018>'
     )
   })
 
@@ -126,9 +126,9 @@ describe('event list', function () {
       bot.response(),
       '_Showing 4 of 7 events_\n' +
       '`6` _G_\n' +
-      '`1` _B_ 17 November 2017\n' +
-      '`3` _D_ 19 November 2017\n' +
-      '`4` _E_ 25 November 2017, 16 December 2017'
+      '`1` _B_ <!date^1510905600^{date}^17 November 2017>\n' +
+      '`3` _D_ <!date^1511078400^{date}^19 November 2017>\n' +
+      '`4` _E_ <!date^1511596800^{date}^25 November 2017>, <!date^1513411200^{date}^16 December 2017>'
     )
   })
 
@@ -146,7 +146,7 @@ describe('event list', function () {
     assert.equal(
       bot.response(),
       '_Showing 1 of 7 events_\n' +
-      '`4` _E_ 25 November 2017, 16 December 2017'
+      '`4` _E_ <!date^1511596800^{date}^25 November 2017>, <!date^1513411200^{date}^16 December 2017>'
     )
   })
 
@@ -156,12 +156,12 @@ describe('event list', function () {
       bot.response(),
       '_Showing 7 of 7 events_\n' +
       '`6` _G_\n' +
-      '`0` A 10 November 2017\n' +
-      '`1` _B_ 17 November 2017\n' +
-      '`2` C 18 November 2017\n' +
-      '`3` _D_ 19 November 2017\n' +
-      '`4` _E_ 25 November 2017, 16 December 2017\n' +
-      '`5` F 10 January 2018'
+      '`0` A <!date^1510300800^{date}^10 November 2017>\n' +
+      '`1` _B_ <!date^1510905600^{date}^17 November 2017>\n' +
+      '`2` C <!date^1510992000^{date}^18 November 2017>\n' +
+      '`3` _D_ <!date^1511078400^{date}^19 November 2017>\n' +
+      '`4` _E_ <!date^1511596800^{date}^25 November 2017>, <!date^1513411200^{date}^16 December 2017>\n' +
+      '`5` F <!date^1515571200^{date}^10 January 2018>'
     )
   })
 })

--- a/test/timespan.test.js
+++ b/test/timespan.test.js
@@ -2,6 +2,7 @@
 
 const {Timespan} = require('../lib/timespan')
 const assert = require('chai').assert
+const moment = require('moment-timezone')
 
 const TZ = 'America/Los_Angeles'
 
@@ -11,64 +12,64 @@ describe('Timespan', function () {
       const t = Timespan.parse('2017-11-17', TZ)
 
       assert.isTrue(t.isFullDay())
-      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
-      assert.isTrue(t.getEnd().isSame('2017-11-17 23:59:59.999', TZ))
+      assert.isTrue(t.getStart().isSame(moment.tz('2017-11-17 00:00:00', TZ)))
+      assert.isTrue(t.getEnd().isSame(moment.tz('2017-11-17 23:59:59.999', TZ)))
     })
 
     it('parses a range of full days', function () {
       const t = Timespan.parse('2017-11-17..2017-11-19', TZ)
 
       assert.isTrue(t.isFullDay())
-      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
-      assert.isTrue(t.getEnd().isSame('2017-11-19 23:59:59.999', TZ))
+      assert.isTrue(t.getStart().isSame(moment.tz('2017-11-17 00:00:00', TZ)))
+      assert.isTrue(t.getEnd().isSame(moment.tz('2017-11-19 23:59:59.999', TZ)))
     })
 
     it('parses a full day plus a duration in days', function () {
       const t = Timespan.parse('2017-11-17+2d', TZ)
 
       assert.isTrue(t.isFullDay())
-      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
-      assert.isTrue(t.getEnd().isSame('2017-11-19 23:59:59.999', TZ))
+      assert.isTrue(t.getStart().isSame(moment.tz('2017-11-17 00:00:00', TZ)))
+      assert.isTrue(t.getEnd().isSame(moment.tz('2017-11-19 23:59:59.999', TZ)))
     })
 
     it('parses a single time as an hour-long span', function () {
       const t = Timespan.parse('2017-11-17 16:00', TZ)
 
       assert.isFalse(t.isFullDay())
-      assert.isTrue(t.getStart().isSame('2017-11-17 16:00:00', TZ))
-      assert.isTrue(t.getEnd().isSame('2017-11-17 17:00:00', TZ))
+      assert.isTrue(t.getStart().isSame(moment.tz('2017-11-17 16:00:00', TZ)))
+      assert.isTrue(t.getEnd().isSame(moment.tz('2017-11-17 17:00:00', TZ)))
     })
 
     it('parses a range of times', function () {
       const t = Timespan.parse('2017-11-17 16:00..2017-11-17 18:00', TZ)
 
       assert.isFalse(t.isFullDay())
-      assert.isTrue(t.getStart().isSame('2017-11-17 16:00:00', TZ))
-      assert.isTrue(t.getEnd().isSame('2017-11-17 18:00:00', TZ))
+      assert.isTrue(t.getStart().isSame(moment.tz('2017-11-17 16:00:00', TZ)))
+      assert.isTrue(t.getEnd().isSame(moment.tz('2017-11-17 18:00:00', TZ)))
     })
 
     it('parses a single time and a duration', function () {
       const t = Timespan.parse('2017-11-17 14:00+2h30m', TZ)
 
       assert.isFalse(t.isFullDay())
-      assert.isTrue(t.getStart().isSame('2017-11-17 14:00:00', TZ))
-      assert.isTrue(t.getEnd().isSame('2017-11-17 16:30:00', TZ))
+      assert.isTrue(t.getStart().isSame(moment.tz('2017-11-17 14:00:00', TZ)))
+      assert.isTrue(t.getEnd().isSame(moment.tz('2017-11-17 16:30:00', TZ)))
     })
 
     it('parses a day and a time', function () {
       const t = Timespan.parse('2017-11-17..2017-11-18 11:00', TZ)
 
       assert.isFalse(t.isFullDay())
-      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
-      assert.isTrue(t.getEnd().isSame('2017-11-18 11:00:00', TZ))
+      assert.isTrue(t.getStart().isSame(moment.tz('2017-11-17 00:00:00', TZ)))
+      assert.isTrue(t.getEnd().isSame(moment.tz('2017-11-18 11:00:00', TZ)))
     })
 
     it('parses a day and a sub-day duration', function () {
       const t = Timespan.parse('2017-11-17+2h', TZ)
 
       assert.isFalse(t.isFullDay())
-      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
-      assert.isTrue(t.getEnd().isSame('2017-11-17 02:00:00', TZ))
+      assert.isTrue(t.getStart().isSame(moment.tz('2017-11-17 00:00:00', TZ)))
+      assert.isTrue(t.getEnd().isSame(moment.tz('2017-11-17 02:00:00', TZ)))
     })
 
     it('becomes invalid on an invalid time', function () {
@@ -88,8 +89,8 @@ describe('Timespan', function () {
       const result = Timespan.deserialize(i)
 
       assert.isFalse(result.isFullDay())
-      assert.isTrue(result.getStart().isSame('2017-11-17 11:00:00', TZ))
-      assert.isTrue(result.getEnd().isSame('2017-11-17 13:00:00', TZ))
+      assert.isTrue(result.getStart().isSame(moment.tz('2017-11-17 11:00:00', TZ)))
+      assert.isTrue(result.getEnd().isSame(moment.tz('2017-11-17 13:00:00', TZ)))
     })
   })
 
@@ -97,27 +98,27 @@ describe('Timespan', function () {
     it('prints a full-day span as a Slack timestamp', function () {
       const ts = Timespan.parse('2017-11-17', TZ)
 
-      assert.equal(ts.renderStart(), '<!date^1510894800^{date}^17 November 2017>')
-      assert.equal(ts.renderRange(), '<!date^1510894800^{date}^17 November 2017>')
+      assert.equal(ts.renderStart(), '<!date^1510905600^{date}^17 November 2017>')
+      assert.equal(ts.renderRange(), '<!date^1510905600^{date}^17 November 2017>')
     })
 
     it('prints a multi-day span as a Slack timestamp', function () {
       const ts = Timespan.parse('2017-11-17..2017-11-19', TZ)
 
-      assert.equal(ts.renderStart(), '<!date^1510894800^{date}^17 November 2017>')
+      assert.equal(ts.renderStart(), '<!date^1510905600^{date}^17 November 2017>')
       assert.equal(
         ts.renderRange(),
-        '<!date^1510894800^{date}^17 November 2017> to <!date^1511153999^{date}^19 November 2017>'
+        '<!date^1510905600^{date}^17 November 2017> to <!date^1511164799^{date}^19 November 2017>'
       )
     })
 
     it('prints a timestamp as a Slack timestamp', function () {
       const ts = Timespan.parse('2017-11-17 11:30', TZ)
 
-      assert.equal(ts.renderStart(), '<!date^1510936200^{date_short} {time}^17 Nov 2017 11:30am>')
+      assert.equal(ts.renderStart(), '<!date^1510947000^{date_short} {time}^17 Nov 2017 11:30am>')
       assert.equal(
         ts.renderRange(),
-        '<!date^1510936200^{date_short} {time}^17 Nov 2017 11:30am> to <!date^1510939800^{time}^12:30pm>'
+        '<!date^1510947000^{date_short} {time}^17 Nov 2017 11:30am> to <!date^1510950600^{time}^12:30pm>'
       )
     })
 
@@ -126,8 +127,8 @@ describe('Timespan', function () {
 
       assert.equal(
         ts.renderRange(),
-        '<!date^1510945200^{date_short} {time}^17 Nov 2017 2:00pm> to ' +
-        '<!date^1511002800^{date_short} {time}^18 Nov 2017 6:00am>'
+        '<!date^1510956000^{date_short} {time}^17 Nov 2017 2:00pm> to ' +
+        '<!date^1511013600^{date_short} {time}^18 Nov 2017 6:00am>'
       )
     })
   })

--- a/test/timespan.test.js
+++ b/test/timespan.test.js
@@ -1,0 +1,134 @@
+/* eslint-env mocha */
+
+const {Timespan} = require('../lib/timespan')
+const assert = require('chai').assert
+
+const TZ = 'America/New_York'
+
+describe('Timespan', function () {
+  describe('parsing', function () {
+    it('parses a single day as a full-day span', function () {
+      const t = Timespan.parse('2017-11-17', TZ)
+
+      assert.isTrue(t.isFullDay())
+      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
+      assert.isTrue(t.getEnd().isSame('2017-11-17 23:59:59.999', TZ))
+    })
+
+    it('parses a range of full days', function () {
+      const t = Timespan.parse('2017-11-17..2017-11-19', TZ)
+
+      assert.isTrue(t.isFullDay())
+      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
+      assert.isTrue(t.getEnd().isSame('2017-11-19 23:59:59.999', TZ))
+    })
+
+    it('parses a full day plus a duration in days', function () {
+      const t = Timespan.parse('2017-11-17+2d', TZ)
+
+      assert.isTrue(t.isFullDay())
+      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
+      assert.isTrue(t.getEnd().isSame('2017-11-19 23:59:59.999', TZ))
+    })
+
+    it('parses a single time as an hour-long span', function () {
+      const t = Timespan.parse('2017-11-17 16:00', TZ)
+
+      assert.isFalse(t.isFullDay())
+      assert.isTrue(t.getStart().isSame('2017-11-17 16:00:00', TZ))
+      assert.isTrue(t.getEnd().isSame('2017-11-17 17:00:00', TZ))
+    })
+
+    it('parses a range of times', function () {
+      const t = Timespan.parse('2017-11-17 16:00..2017-11-17 18:00', TZ)
+
+      assert.isFalse(t.isFullDay())
+      assert.isTrue(t.getStart().isSame('2017-11-17 16:00:00', TZ))
+      assert.isTrue(t.getEnd().isSame('2017-11-17 18:00:00', TZ))
+    })
+
+    it('parses a single time and a duration', function () {
+      const t = Timespan.parse('2017-11-17 14:00+2h30m', TZ)
+
+      assert.isFalse(t.isFullDay())
+      assert.isTrue(t.getStart().isSame('2017-11-17 14:00:00', TZ))
+      assert.isTrue(t.getEnd().isSame('2017-11-17 16:30:00', TZ))
+    })
+
+    it('parses a day and a time', function () {
+      const t = Timespan.parse('2017-11-17..2017-11-18 11:00', TZ)
+
+      assert.isFalse(t.isFullDay())
+      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
+      assert.isTrue(t.getEnd().isSame('2017-11-18 11:00:00', TZ))
+    })
+
+    it('parses a day and a sub-day duration', function () {
+      const t = Timespan.parse('2017-11-17+2h', TZ)
+
+      assert.isFalse(t.isFullDay())
+      assert.isTrue(t.getStart().isSame('2017-11-17 00:00:00', TZ))
+      assert.isTrue(t.getEnd().isSame('2017-11-17 02:00:00', TZ))
+    })
+
+    it('becomes invalid on an invalid time', function () {
+      assert.isFalse(Timespan.parse('2017-33-76').isValid())
+    })
+
+    it('becomes invalid on an invalid duration', function () {
+      assert.isFalse(Timespan.parse('2017-11-17 11:00+2x', TZ).isValid())
+    })
+  })
+
+  describe('serialization', function () {
+    it('round-trips itself through a JSON-able representation', function () {
+      const ts = Timespan.parse('2017-11-17 11:00:00..2017-11-17 13:00:00', TZ)
+      const o = ts.serialize()
+      const i = JSON.parse(JSON.stringify(o))
+      const result = Timespan.deserialize(i)
+
+      assert.isFalse(result.isFullDay())
+      assert.isTrue(result.getStart().isSame('2017-11-17 11:00:00', TZ))
+      assert.isTrue(result.getEnd().isSame('2017-11-17 13:00:00', TZ))
+    })
+  })
+
+  describe('printing', function () {
+    it('prints a full-day span as a Slack timestamp', function () {
+      const ts = Timespan.parse('2017-11-17', TZ)
+
+      assert.equal(ts.renderStart(), '<!date^1510894800^{date}^17 November 2017>')
+      assert.equal(ts.renderRange(), '<!date^1510894800^{date}^17 November 2017>')
+    })
+
+    it('prints a multi-day span as a Slack timestamp', function () {
+      const ts = Timespan.parse('2017-11-17..2017-11-19', TZ)
+
+      assert.equal(ts.renderStart(), '<!date^1510894800^{date}^17 November 2017>')
+      assert.equal(
+        ts.renderRange(),
+        '<!date^1510894800^{date}^17 November 2017> to <!date^1511153999^{date}^19 November 2017>'
+      )
+    })
+
+    it('prints a timestamp as a Slack timestamp', function () {
+      const ts = Timespan.parse('2017-11-17 11:30', TZ)
+
+      assert.equal(ts.renderStart(), '<!date^1510936200^{date_short} {time}^17 Nov 2017 11:30am>')
+      assert.equal(
+        ts.renderRange(),
+        '<!date^1510936200^{date_short} {time}^17 Nov 2017 11:30am> to <!date^1510939800^{time}^12:30pm>'
+      )
+    })
+
+    it('prints a multi-day timespan as a Slack timestamp', function () {
+      const ts = Timespan.parse('2017-11-17 14:00..2017-11-18 06:00', TZ)
+
+      assert.equal(
+        ts.renderRange(),
+        '<!date^1510945200^{date_short} {time}^17 Nov 2017 2:00pm> to ' +
+        '<!date^1511002800^{date_short} {time}^18 Nov 2017 6:00am>'
+      )
+    })
+  })
+})

--- a/test/timespan.test.js
+++ b/test/timespan.test.js
@@ -72,7 +72,7 @@ describe('Timespan', function () {
     })
 
     it('becomes invalid on an invalid time', function () {
-      assert.isFalse(Timespan.parse('2017-33-76').isValid())
+      assert.isFalse(Timespan.parse('2017-33-76', TZ).isValid())
     })
 
     it('becomes invalid on an invalid duration', function () {

--- a/test/timespan.test.js
+++ b/test/timespan.test.js
@@ -3,7 +3,7 @@
 const {Timespan} = require('../lib/timespan')
 const assert = require('chai').assert
 
-const TZ = 'America/New_York'
+const TZ = 'America/Los_Angeles'
 
 describe('Timespan', function () {
   describe('parsing', function () {


### PR DESCRIPTION
Improve the expressiveness of `--propose` and `--at` argument parsing to support arbitrary time spans for events.

You should be able to specify events as ranges of times:

```
--propose 2017-12-13T11:00..2017-12-13T13:00
```

Or as a start time and a duration:

```
--propose 2017-12-13T11:00+2h
```

Additionally, events should be aware of the distinction between "full day" events that only specify to the day and more granular events that specify hours or minutes for their start and end times. (iCal feeds have a special flag for this, so we can take advantage of it there.)

When events are rendered, timestamps should be formatted with Slack's [`<!date>` syntax](https://api.slack.com/docs/message-formatting#formatting_dates) so they appear in the native timezone of each viewer.

Fixes #6.